### PR TITLE
Temp State

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ OBJS=\
   obj/hmac-ratchet.o \
   obj/session.o \
   obj/socket.o \
+  obj/state.o \
   obj/wrappers.o
 
 TESTS=\

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -1,14 +1,8 @@
 #include "cache.h"
 
 namespace Spud {
-  Cache::Cache(uint32_t count) {
-    mIndex  = 0;
-    mCount  = count;
-    mEpochs = new ID[count];
-  }
-
-  Cache::~Cache() {
-    delete [] mEpochs;
+  Cache::Cache(): mEpochs(), mIndex(0) {
+    // All done.
   }
 
   void Cache::del(const uint8_t rk[32], uint32_t n) {
@@ -26,7 +20,7 @@ namespace Spud {
     ID cachekey(rk, n);
     mCache.erase(mEpochs[mIndex]);
     mEpochs[mIndex] = cachekey;
-    mIndex = (mIndex + 1) % mCount;
+    mIndex = (mIndex + 1) % 32;
 
     mCache[cachekey] = key;
   }

--- a/src/cache.h
+++ b/src/cache.h
@@ -28,12 +28,10 @@ namespace Spud {
     };
   protected:
     std::map<ID, Key> mCache;
-    ID*       mEpochs;
+    ID        mEpochs[32];
     uint32_t  mIndex;
-    uint32_t  mCount;
   public:
-    Cache(uint32_t count);
-    ~Cache();
+    Cache();
 
     void       del(const uint8_t rk[32], uint32_t n);
     const Key* get(const uint8_t rk[32], uint32_t n) const;

--- a/src/dh-ratchet.cpp
+++ b/src/dh-ratchet.cpp
@@ -16,6 +16,14 @@ static void printhex(const char* header, const uint8_t* data, uint32_t length) {
 }
 
 namespace Spud {
+  DHRatchet::DHRatchet(const DHRatchet& other) {
+    mPublic = other.mPublic;
+    mSecret = other.mSecret;
+    mRemote = other.mRemote;
+    mShared = other.mShared;
+    mOutput = other.mOutput;
+  }
+
   DHRatchet::DHRatchet(const uint8_t init[32], const uint8_t rk[32]) {
     mOutput = init;
     mRemote = rk;
@@ -27,13 +35,6 @@ namespace Spud {
     mRemote = ZERO_CONSTANT;
     mPublic = pk;
     mSecret = sk;
-  }
-
-  DHRatchet::DHRatchet(const uint8_t init[32], const uint8_t pk[32], const uint8_t sk[32], const uint8_t rk[32]) {
-    mOutput = init;
-    mPublic = pk;
-    mSecret = sk;
-    refresh(rk);
   }
 
   void DHRatchet::debug() const {

--- a/src/dh-ratchet.h
+++ b/src/dh-ratchet.h
@@ -10,15 +10,15 @@
 namespace Spud {
   class DHRatchet {
   protected:
-    Key      mPublic;
-    Key      mSecret;
-    Key      mRemote;
-    Key      mShared;
-    Key      mOutput;
+    Key mPublic;
+    Key mSecret;
+    Key mRemote;
+    Key mShared;
+    Key mOutput;
   public:
+    DHRatchet(const DHRatchet& other);
     DHRatchet(const uint8_t init[32], const uint8_t rk[32]);
     DHRatchet(const uint8_t init[32], const uint8_t pk[32], const uint8_t sk[32]);
-    DHRatchet(const uint8_t init[32], const uint8_t pk[32], const uint8_t sk[32], const uint8_t rk[32]);
 
     void debug() const;
     const Key& output() const;

--- a/src/hmac-ratchet.cpp
+++ b/src/hmac-ratchet.cpp
@@ -16,6 +16,14 @@ static void printhex(const char* header, const uint8_t* data, uint32_t length) {
 }
 
 namespace Spud {
+  HMACRatchet::HMACRatchet(const HMACRatchet& other) {
+    mSetupKey = other.mSetupKey;
+    mChainKey = other.mChainKey;
+    mValueKey = other.mValueKey;
+    mCount    = other.mCount;
+    mPrev     = other.mPrev;
+  }
+
   HMACRatchet::HMACRatchet(const uint8_t init[32], const uint8_t key[32]): mCount(0) {
     mSetupKey = init;
     refresh(key);

--- a/src/hmac-ratchet.h
+++ b/src/hmac-ratchet.h
@@ -16,6 +16,7 @@ namespace Spud {
     uint32_t mCount;
     uint32_t mPrev;
   public:
+    HMACRatchet(const HMACRatchet& other);
     HMACRatchet(const uint8_t init[32], const uint8_t key[32]);
 
     uint32_t count() const;

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -1,130 +1,25 @@
 #include "session.h"
 
-#include "error.h"
-#include "wrappers.h"
-
-#include <cstdio>
-
-// Read 32 bits from network byte order:
-static inline uint32_t r32(const uint8_t* bytes) {
-  uint32_t a = uint32_t(bytes[0]) << 24;
-  uint32_t b = uint32_t(bytes[1]) << 16;
-  uint32_t c = uint32_t(bytes[2]) <<  8;
-  uint32_t d = uint32_t(bytes[3]) <<  0;
-  return a | b | c | d;
-}
-
-// Store 32 bits in network byte order:
-static inline void w32(uint32_t value, uint8_t* bytes) {
-  bytes[0] = value >> 24;
-  bytes[1] = value >> 16;
-  bytes[2] = value >>  8;
-  bytes[3] = value >>  0;
-}
-
-// Thirty-two bytes of constant:       01234567890123456789012345678901234567890
-static const uint8_t ROOT_CONSTANT[] = "so y'all need a root ratchet...";
-static const uint8_t SEND_CONSTANT[] = "this'll initialize send ratchets";
-static const uint8_t RECV_CONSTANT[] = "and this one'll do recv ratchets";
-
-// Message layout (bytes):
-//  0 - 31: Authentication Code
-// 32 - 63: Next DH Key
-// 64 - 67: Current Message Number
-// 68 - 71: Previous Message Count
-// 72 - ??: Message Data
-
 namespace Spud {
-  Session::Session(const uint8_t rk[32]):
-    mRootChain(ROOT_CONSTANT, rk),
-    mSendChain(SEND_CONSTANT, mRootChain.output()),
-    mRecvChain(RECV_CONSTANT, mRootChain.output()),
-    mKeyCache(128)
-  {
+  Session::Session(const uint8_t rk[32]): mState(rk) {
     // Client-side (creates an ephemeral keypair).
   }
 
-  Session::Session(const uint8_t pk[32], const uint8_t sk[32]):
-    mRootChain(ROOT_CONSTANT, pk, sk),
-    mSendChain(RECV_CONSTANT, mRootChain.output()),
-    mRecvChain(SEND_CONSTANT, mRootChain.output()),
-    mKeyCache(128)
-  {
+  Session::Session(const uint8_t pk[32], const uint8_t sk[32]): mState(pk, sk) {
     // Server-side with a known keypair.
-    // Note that the send/recv constants are swapped!
-  }
-
-  Session::~Session() {
-    // Nothing to do.
   }
 
   uint32_t Session::decode(const uint8_t* c, uint32_t cl, uint8_t* m, uint32_t ml) {
-    uint32_t mn = r32(c + 64);
-    uint32_t pn = r32(c + 68);
-
-    if(ml < cl - 72) {
-      throw Spud::Error("Buffer too short to hold message!");
-    }
-
-    const Key* k = key(c + 32, mn, pn);
-    if(k == NULL) throw Spud::Error("Could not find decryption key.");
-    if(!Spud::verify(c, c + 32, cl - 32, *k)) {
-      throw Spud::Error("Invalid message authentication code.");
-    }
-
-    // Note: Using the message numbers / counts (c[64:72]) as a nonce.
-    Spud::decrypt(c + 72, m, cl - 72, c + 64, *k);
-    mKeyCache.del(c + 32, mn);
-    return cl - 72;
+    State idaho(mState);
+    ml = idaho.decode(c, cl, m, ml);
+    mState = idaho;
+    return ml;
   }
 
   uint32_t Session::encode(uint8_t* c, uint32_t cl, const uint8_t* m, uint32_t ml) {
-    if(cl < ml + 72) {
-      throw Spud::Error("Buffer too short to hold ciphertext!");
-    }
-
-    mSendChain.ratchet();
-    std::memcpy(c + 32, mRootChain.publik(), 32);
-    w32(mSendChain.count(), c + 64);
-    w32(mSendChain.prev(),  c + 68);
-
-    Spud::encrypt(c + 72, m, ml, c + 64, mSendChain.output());
-    Spud::mac(c, c + 32, ml + 40, mSendChain.output());
-    return ml + 72;
-  }
-
-  const Key* Session::key(const uint8_t rk[32], uint32_t mn, uint32_t pn) {
-    if(mRootChain.remote() != rk) {
-      // Skip unseen keys from the old chain:
-      seek(mRootChain.remote(), pn);
-
-      // Generate a new root key:
-      mRootChain.refresh(rk);
-      mRecvChain.refresh(mRootChain.output());
-      mRootChain.refresh();
-      mSendChain.refresh(mRootChain.output());
-    }
-
-    // Skip unseen keys from the new/current chain:
-    seek(mRootChain.remote(), mn - 1);
-    if(mRecvChain.count() == mn - 1) {
-      mRecvChain.ratchet();
-      return &mRecvChain.output();
-    }
-
-    return mKeyCache.get(rk, mn);
-  }
-
-  void Session::seek(const uint8_t rk[32], uint32_t n) {
-    if(n > mRecvChain.count()) {
-      if(n - mRecvChain.count() > 8) {
-        throw Spud::Error("Too many keys to skip.");
-      }
-
-      while(mRecvChain.count() < n) {
-        mRecvChain.ratchet();
-        mKeyCache.set(rk, mRecvChain.count(), mRecvChain.output());
-      }
-    }
+    State idaho(mState);
+    ml = idaho.encode(c, cl, m, ml);
+    mState = idaho;
+    return ml;
   }
 }

--- a/src/session.h
+++ b/src/session.h
@@ -1,9 +1,7 @@
 #ifndef SPUD_SESSION_H
 #define SPUD_SESSION_H
 
-#include "cache.h"
-#include "dh-ratchet.h"
-#include "hmac-ratchet.h"
+#include "state.h"
 
 // This is where all the action is.
 // A Session keeps track of all the ratchets for one end of a single connection.
@@ -13,20 +11,13 @@
 namespace Spud {
   class Session {
   protected:
-    DHRatchet   mRootChain;
-    HMACRatchet mSendChain;
-    HMACRatchet mRecvChain;
-    Cache       mKeyCache;
+    State mState;
   public:
     Session(const uint8_t rk[32]);
     Session(const uint8_t pk[32], const uint8_t sk[32]);
-    Session(const uint8_t pk[32], const uint8_t sk[32], const uint8_t rk[32]);
-    ~Session();
 
-    uint32_t   decode(const uint8_t* c, uint32_t cl, uint8_t* m, uint32_t ml);
-    uint32_t   encode(uint8_t* c, uint32_t cl, const uint8_t* m, uint32_t ml);
-    const Key* key(const uint8_t rk[32], uint32_t mn, uint32_t pn);
-    void       seek(const uint8_t rk[32], uint32_t n);
+    uint32_t decode(const uint8_t* c, uint32_t cl, uint8_t* m, uint32_t ml);
+    uint32_t encode(uint8_t* c, uint32_t cl, const uint8_t* m, uint32_t ml);
   };
 }
 

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1,0 +1,133 @@
+#include "state.h"
+
+#include "error.h"
+#include "wrappers.h"
+
+// Read 32 bits from network byte order:
+static inline uint32_t r32(const uint8_t* bytes) {
+  uint32_t a = uint32_t(bytes[0]) << 24;
+  uint32_t b = uint32_t(bytes[1]) << 16;
+  uint32_t c = uint32_t(bytes[2]) <<  8;
+  uint32_t d = uint32_t(bytes[3]) <<  0;
+  return a | b | c | d;
+}
+
+// Store 32 bits in network byte order:
+static inline void w32(uint32_t value, uint8_t* bytes) {
+  bytes[0] = value >> 24;
+  bytes[1] = value >> 16;
+  bytes[2] = value >>  8;
+  bytes[3] = value >>  0;
+}
+
+// Thirty-two bytes of constant:       01234567890123456789012345678901234567890
+static const uint8_t ROOT_CONSTANT[] = "so y'all need a root ratchet...";
+static const uint8_t SEND_CONSTANT[] = "this'll initialize send ratchets";
+static const uint8_t RECV_CONSTANT[] = "and this one'll do recv ratchets";
+
+// Message layout (bytes):
+//  0 - 31: Authentication Code
+// 32 - 63: Next DH Key
+// 64 - 67: Current Message Number
+// 68 - 71: Previous Message Count
+// 72 - ??: Message Data
+
+namespace Spud {
+  State::State(const State& other):
+    mRootChain(other.mRootChain),
+    mSendChain(other.mSendChain),
+    mRecvChain(other.mRecvChain),
+    mKeyCache(other.mKeyCache)
+  {
+    // All done.
+  }
+
+  State::State(const uint8_t rk[32]):
+    mRootChain(ROOT_CONSTANT, rk),
+    mSendChain(SEND_CONSTANT, mRootChain.output()),
+    mRecvChain(RECV_CONSTANT, mRootChain.output()),
+    mKeyCache()
+  {
+    // Client-side (creates an ephemeral keypair).
+  }
+
+  State::State(const uint8_t pk[32], const uint8_t sk[32]):
+    mRootChain(ROOT_CONSTANT, pk, sk),
+    mSendChain(RECV_CONSTANT, mRootChain.output()),
+    mRecvChain(SEND_CONSTANT, mRootChain.output()),
+    mKeyCache()
+  {
+    // Server-side with a known keypair.
+    // Note that the send/recv constants are swapped!
+  }
+
+  uint32_t State::decode(const uint8_t* c, uint32_t cl, uint8_t* m, uint32_t ml) {
+    uint32_t mn = r32(c + 64);
+    uint32_t pn = r32(c + 68);
+
+    if(ml < cl - 72) {
+      throw Spud::Error("Buffer too short to hold message!");
+    }
+
+    const Key* k = key(c + 32, mn, pn);
+    if(k == NULL) throw Spud::Error("Could not find decryption key.");
+    if(!Spud::verify(c, c + 32, cl - 32, *k)) {
+      throw Spud::Error("Invalid message authentication code.");
+    }
+
+    // Note: Using the message numbers / counts (c[64:72]) as a nonce.
+    Spud::decrypt(c + 72, m, cl - 72, c + 64, *k);
+    mKeyCache.del(c + 32, mn);
+    return cl - 72;
+  }
+
+  uint32_t State::encode(uint8_t* c, uint32_t cl, const uint8_t* m, uint32_t ml) {
+    if(cl < ml + 72) {
+      throw Spud::Error("Buffer too short to hold ciphertext!");
+    }
+
+    mSendChain.ratchet();
+    std::memcpy(c + 32, mRootChain.publik(), 32);
+    w32(mSendChain.count(), c + 64);
+    w32(mSendChain.prev(),  c + 68);
+
+    Spud::encrypt(c + 72, m, ml, c + 64, mSendChain.output());
+    Spud::mac(c, c + 32, ml + 40, mSendChain.output());
+    return ml + 72;
+  }
+
+  const Key* State::key(const uint8_t rk[32], uint32_t mn, uint32_t pn) {
+    if(mRootChain.remote() != rk) {
+      // Skip unseen keys from the old chain:
+      seek(mRootChain.remote(), pn);
+
+      // Generate a new root key:
+      mRootChain.refresh(rk);
+      mRecvChain.refresh(mRootChain.output());
+      mRootChain.refresh();
+      mSendChain.refresh(mRootChain.output());
+    }
+
+    // Skip unseen keys from the new/current chain:
+    seek(mRootChain.remote(), mn - 1);
+    if(mRecvChain.count() == mn - 1) {
+      mRecvChain.ratchet();
+      return &mRecvChain.output();
+    }
+
+    return mKeyCache.get(rk, mn);
+  }
+
+  void State::seek(const uint8_t rk[32], uint32_t n) {
+    if(n > mRecvChain.count()) {
+      if(n - mRecvChain.count() > 8) {
+        throw Spud::Error("Too many keys to skip.");
+      }
+
+      while(mRecvChain.count() < n) {
+        mRecvChain.ratchet();
+        mKeyCache.set(rk, mRecvChain.count(), mRecvChain.output());
+      }
+    }
+  }
+}

--- a/src/state.h
+++ b/src/state.h
@@ -1,0 +1,32 @@
+#ifndef SPUD_STATE_H
+#define SPUD_STATE_H
+
+#include "cache.h"
+#include "dh-ratchet.h"
+#include "hmac-ratchet.h"
+
+
+// Used to store Session state.
+// This makes it easy for Session to make a copy of its state for trial decryptions.
+// Also: Idaho
+
+namespace Spud {
+  class State {
+  protected:
+    DHRatchet   mRootChain;
+    HMACRatchet mSendChain;
+    HMACRatchet mRecvChain;
+    Cache       mKeyCache;
+  public:
+    State(const State& other);
+    State(const uint8_t rk[32]);
+    State(const uint8_t pk[32], const uint8_t sk[32]);
+
+    uint32_t   decode(const uint8_t* c, uint32_t cl, uint8_t* m, uint32_t ml);
+    uint32_t   encode(uint8_t* c, uint32_t cl, const uint8_t* m, uint32_t ml);
+    const Key* key(const uint8_t rk[32], uint32_t mn, uint32_t pn);
+    void       seek(const uint8_t rk[32], uint32_t n);
+  };
+}
+
+#endif

--- a/test/session.cpp
+++ b/test/session.cpp
@@ -118,7 +118,7 @@ Moka::Context tests("Session", [](Moka::Context& it) {
 
     uint32_t cl1 = a.encode(c1, 256, m1, 14);
     uint32_t cl2 = x.encode(c2, 256, m2, 19);
-    uint32_t cl3 = a.encode(c3, 256, m2, 14);
+    uint32_t cl3 = a.encode(c3, 256, m3, 14);
 
     uint32_t dl1 = b.decode(c1, cl1, d1, 256);
     must_equal(dl1, 14);
@@ -129,7 +129,7 @@ Moka::Context tests("Session", [](Moka::Context& it) {
     });
 
     uint32_t dl3 = b.decode(c3, cl3, d3, 256);
-    must_equal(dl3, 19);
+    must_equal(dl3, 14);
     must_equal(std::memcmp(m3, d3, dl3), 0);
   });
 });


### PR DESCRIPTION
This moves everything that was in `Session` into a new copyable `State` class.  `Session` now simply clones its existing state, hands off `encode` or `decode` to that new temp state object, and then replaces its official state if the temp state completes its job without throwing an exception.